### PR TITLE
Cleanup code and make nice CLI scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+__pycache__

--- a/backend.py
+++ b/backend.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+from bw2data import mapping, databases, config
+from bw2data.backends.peewee import SQLiteBackend
+from bw2data.utils import MAX_INT_32, TYPE_DICTIONARY
+from bw2data.errors import UnknownObject
+import datetime
+import itertools
+import numpy as np
+
+
+class ProcessedBackend(SQLiteBackend):
+    """Don't write the data, just the processed arrays."""
+    backend = "processed"
+
+    def write(self, data):
+        """Process inventory documents to NumPy structured arrays."""
+        if self.name not in databases:
+            self.register()
+
+        mapping.add(data.keys())
+
+        # Figure out when the production exchanges are implicit
+        missing_production_keys = [
+            key for key, value in data.items()
+            if not [1 for exc in value.get('exchanges') if exc['type'] == 'production']
+        ]
+
+        num_exchanges = sum(1 for ds in data.values() for exc in ds.get('exchanges'))
+        num_processes = len(data)
+
+        arr = np.zeros((num_exchanges + len(missing_production_keys), ), dtype=self.dtype)
+
+        for index, row in enumerate(exc for ds in data.values() for exc in ds.get('exchanges')):
+            if "type" not in row:
+                raise UntypedExchange
+            if "amount" not in row or "input" not in row:
+                raise InvalidExchange
+            if np.isnan(row['amount']) or np.isinf(row['amount']):
+                raise ValueError("Invalid amount in exchange {}".format(row))
+
+            try:
+                arr[index] = (
+                    mapping[row['input']],
+                    mapping[row['output']],
+                    MAX_INT_32,
+                    MAX_INT_32,
+                    TYPE_DICTIONARY[row["type"]],
+                    row.get("uncertainty type", 0),
+                    row["amount"],
+                    row["amount"] \
+                        if row.get("uncertainty type", 0) in (0,1) \
+                        else row.get("loc", np.NaN),
+                    row.get("scale", np.NaN),
+                    row.get("shape", np.NaN),
+                    row.get("minimum", np.NaN),
+                    row.get("maximum", np.NaN),
+                    row["amount"] < 0
+                )
+            except KeyError:
+                raise UnknownObject(("Exchange between {} and {} is invalid "
+                    "- one of these objects is unknown (i.e. doesn't exist "
+                    "as a process dataset)"
+                    ).format(
+                        row['input'],
+                        row['output']
+                    )
+                )
+
+        # If exchanges were found, start inserting rows at len(exchanges) + 1
+        index += 1
+
+        for index, key in zip(itertools.count(index), missing_production_keys):
+            arr[index] = (
+                mapping[key], mapping[key],
+                MAX_INT_32, MAX_INT_32, TYPE_DICTIONARY["production"],
+                0, 1, 1, np.NaN, np.NaN, np.NaN, np.NaN, False
+            )
+
+        databases[self.name]['depends'] = ['biosphere3', 'ecoinvent']  # Why are we hard-coding this again!?
+        databases[self.name]['processed'] = datetime.datetime.now().isoformat()
+        databases.flush()
+
+        arr.sort(order=self.dtype_field_order())
+        np.save(self.filepath_processed(), arr, allow_pickle=False)
+
+    def process(self):
+        """No-op; no intermediate data to process"""
+        return
+
+
+config.backends['processed'] = ProcessedBackend

--- a/comparison_cli.py
+++ b/comparison_cli.py
@@ -86,8 +86,7 @@ def main(version, methods, cutoff, cpus, output, iterations):
     already_treated = [file[:-7] for file in os.listdir(output)
                        if file[-7:] == '.pickle']
     to_treat = [act.key for act in ecoinvent
-                if act.key[1] not in already_treated][:20]
-
+                if act.key[1] not in already_treated]
     activity_sublists = chunks(to_treat, ceil( len(to_treat) / cpus ))
 
     workers = []

--- a/comparison_cli.py
+++ b/comparison_cli.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+from brightway2 import *
+from bw2data.utils import random_string
+from create_tree import Tree # Code used to generate "branch and leaf" systems
+from math import ceil
+from time import sleep
+import click
+import multiprocessing as mp
+import numpy as np
+import os
+import pickle
+import time
+
+
+DEFAULT_METHODS = [
+    ('ReCiPe Midpoint (H)', 'metal depletion', 'MDP'),
+    ('ReCiPe Midpoint (H)', 'water depletion', 'WDP'),
+    ('ReCiPe Midpoint (H)', 'urban land occupation', 'ULOP'),
+    ('ReCiPe Midpoint (H)', 'terrestrial ecotoxicity', 'TETPinf'),
+    ('ReCiPe Midpoint (H)', 'marine eutrophication', 'MEP'),
+    ('ReCiPe Midpoint (H)', 'freshwater ecotoxicity', 'FETPinf'),
+    ('ReCiPe Midpoint (H)', 'photochemical oxidant formation', 'POFP'),
+    ('ReCiPe Midpoint (H)', 'particulate matter formation', 'PMFP'),
+    ('ReCiPe Midpoint (H)', 'ionising radiation', 'IRP_HE'),
+    ('ReCiPe Midpoint (H)', 'marine ecotoxicity', 'METPinf'),
+    ('ReCiPe Midpoint (H)', 'human toxicity', 'HTPinf'),
+    ('ReCiPe Midpoint (H)', 'ozone depletion', 'ODPinf'),
+    ('ReCiPe Midpoint (H)', 'agricultural land occupation', 'ALOP'),
+    ('ReCiPe Midpoint (H)', 'freshwater eutrophication', 'FEP'),
+    ('ReCiPe Midpoint (H)', 'fossil depletion', 'FDP'),
+    ('ReCiPe Midpoint (H)', 'natural land transformation', 'NLTP'),
+    ('ReCiPe Midpoint (H)', 'climate change', 'GWP100')
+]
+
+
+def chunks(l, n):
+    return [l[i:i+n] for i in range(0, len(l), n)]
+
+
+@click.command()
+@click.option('--version', help='Ecoinvent version (2 or 3)', type=int)
+@click.option('--methods', default=None, help='JSON file with list of methods')
+@click.option('--cutoff', help='Cutoff value in (0, 1)', type=float)
+@click.option('--iterations', default=1000, help='Number of Monte Carlo iterations', type=int)
+@click.option('--cpus', default=mp.cpu_count(), help='Number of used CPU cores', type=int)
+@click.option('--output', help='Output directory path',
+              default=r'E:\test\network_tree_comparison\raw')
+def main(version, methods, cutoff, cpus, output, iterations):
+    """Module used to compare the uncertainty of networks and trees.
+
+    Uses Brightway2 framework and the Tree class. For a list of
+    activities, Monte Carlo is carried out both on the network
+    representation of the product system and on "rooted tree"
+    versions.
+
+    """
+    if version not in (2,3):
+        print("Need valid version number")
+        return
+
+    base_project = "2.2 tree base" if version == 2 else "3.3 tree base"
+
+    if methods is None:
+        methods = DEFAULT_METHODS
+    else:
+        raise NotImplemented("Not done yet")
+
+    if not 0 < cutoff < 1:
+        print("Invalid cutoff value")
+        return
+
+    if not output or not os.path.isdir(output):
+        print("This is not a valid path: {}".format(output))
+        return
+
+    assert cpus
+    assert iterations
+
+    projects.set_current(base_project)
+
+    ecoinvent = Database('ecoinvent')
+
+    # In case you need to stop and restart program
+    # Results are stored by the activity code + ".pickle" - subtract
+    # even characters to get the code back.
+    already_treated = [file[:-7] for file in os.listdir(output)
+                       if file[-7:] == '.pickle']
+    to_treat = [act.key for act in ecoinvent
+                if act.key[1] not in already_treated][:20]
+
+    activity_sublists = chunks(to_treat, ceil( len(to_treat) / cpus ))
+
+    workers = []
+    for index, sub_list in enumerate(activity_sublists):
+        j = mp.Process(target=tree_worker,
+                       args=(base_project,
+                             sub_list,
+                             cutoff,
+                             methods,
+                             iterations,
+                             output,
+                             index
+                            )
+                       )
+        workers.append(j)
+    for w in workers:
+        print("starting worker {}".format(w))
+        w.start()
+        sleep(3)
+
+
+def get_characterization_matrices(demand, list_of_methods):
+    characterization_matrices = {}
+    sacrificial_LCA = LCA({demand:1})
+    sacrificial_LCA.lci()
+    for method in list_of_methods:
+        sacrificial_LCA.switch_method(method)
+        characterization_matrices[method] = sacrificial_LCA.characterization_matrix.copy()
+    return characterization_matrices
+
+
+def tree_worker(base_project, activities, cutoff,
+                list_methods, iterations, output_fp, worker_id):
+    """Function that generates Monte Carlo results for network and tree
+    representations of product systems."""
+
+    # Create new project for this worker. Will be deleted later.
+    projects.set_current(base_project)
+    new_project_name = "temp project {}".format(random_string())
+    projects.copy_project(new_project_name)
+
+    ecoinvent = Database('ecoinvent')
+
+    # Generate matrices with characterization factors. This is much faster than
+    # using "switch_method" during Monte Carlo.
+    characterization_matrices = get_characterization_matrices(activities[0], list_methods)
+
+    for i, act_key in enumerate(activities):
+        act = get_activity(act_key)
+
+        # Create dict with tree specifications (in terms of cut-off)
+        model_types = ['network', 'deterministic', 'tree-{}'.format(cutoff)]
+
+        # Generate results collector
+        results = {method: {} for method in list_methods}
+        for method in list_methods:
+            for model_type in model_types:
+                if model_type != 'deterministic':
+                    results[method][model_type] = np.zeros(iterations)
+
+        # Generate metadata collector
+        tree_metadata = {}
+
+        # Deterministic
+        lca = LCA({act:1})
+        lca.lci()
+        for method, cfs in characterization_matrices.items():
+            results[method]['deterministic'] = (cfs * lca.inventory).sum()
+
+        MC = MonteCarloLCA({act:1})
+        for iteration in range(iterations):
+            s = next(MC) # s contains supply array
+            lci = MC.biosphere_matrix * s
+            for method, cfs in characterization_matrices.items():
+                results[method]['network'][iteration] = (cfs*lci).sum()
+
+        # Tree LCAs
+        tree = Tree({act:1})
+        tree.traverse(list_methods,
+                      'temp-{}'.format(act['code']),
+                      cutoff=cutoff,
+                      store_leaves_as_scores=False)
+
+        # Store some information on tree
+        tree_metadata = {}
+        tree_metadata['number of branches'] = len(tree.list_branches)
+        tree_metadata['number of leaves'] = len(tree.list_leafs)
+        tree_metadata['branch_contribution'] = {}
+
+        for method in tree.methods:
+            tree_metadata['branch_contribution'][method] = 0
+            for node in tree.listTreeNodeDatasets:
+                if (node['node type'] == 'branch' or
+                    node['node type'] == 'root'):
+                    tree_metadata['branch_contribution'][method] += (
+                        node['gate-to-gate contribution'][method] /
+                            tree.scores[method]
+                    )
+
+        tree.write_tree()
+
+        # Do Monte Carlo
+        MC = MonteCarloLCA({tree.root:1})
+        for iteration in range(iterations):
+            s = next(MC)
+            lci = MC.biosphere_matrix * s
+            for method, cfs in characterization_matrices.items():
+                results[method]['tree-{}'.format(cutoff)][iteration] = (cfs * lci).sum()
+
+        #Dump results to disk
+        with open(os.path.join(output_fp, "{}.pickle".format(act['code'])),"wb") as f:
+            pickle.dump(results, f, protocol=pickle.HIGHEST_PROTOCOL)
+        with open(os.path.join(output_fp,
+                               "_metadata_{}.pickle".format(act['code'])),
+                 "wb") as f:
+            pickle.dump(tree_metadata, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    projects.delete_project(new_project_name, True)
+
+if __name__ == "__main__":
+    main()

--- a/create_tree.py
+++ b/create_tree.py
@@ -23,6 +23,7 @@ Developed by Pascal Lesage and Chris Mutel.
 """
 
 from brightway2 import *
+from backend import ProcessedBackend
 import collections
 import copy
 import itertools
@@ -239,9 +240,12 @@ class Tree(object):
                 if not exc['input'] == exc['output']:
                     dataset['exchanges'].append(exc_dataset)
             self.listTreeNodeDatasets.append(dataset)
-   
-    def write_new_data(self, new_name, node_data):
-        database = Database(new_name)
+
+    def write_new_data(self, new_name, node_data, only_processed=True):
+        if only_processed:
+            database = ProcessedBackend(new_name)
+        else:
+            database = Database(new_name)
         database.write({(o['database'], o['code']): o for o in node_data})
         return database
 

--- a/setup_projects.py
+++ b/setup_projects.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+import click
+import os
+from brightway2 import *
+
+
+@click.command()
+@click.option('--version', help='Ecoinvent version (2 or 3)', type=int)
+@click.option('--path', help='Directory path for ecoinvent input data')
+def main(version, path):
+    """Setup base projects for ecoinvent 2.2 and 3.3."""
+    if version not in (2,3):
+        print("Need valid version number")
+        return
+
+    if not path or not os.path.isdir(path):
+        print("This is not a valid path: {}".format(path))
+        return
+
+    project_name = "2.2 tree base" if version == 2 else "3.3 tree base"
+
+    if project_name in projects:
+        print("This project already exists: {}".format(project_name))
+        return
+
+    projects.set_current(project_name)
+    bw2setup()
+
+    if version == 2:
+        ei22 = SingleOutputEcospold1Importer(
+            path,
+            'ecoinvent')
+        ei22.apply_strategies()
+        ei22.write_database()
+    else:
+        ei33cu = SingleOutputEcospold2Importer(
+            path,
+            'ecoinvent')
+        ei33cu.apply_strategies()
+        ei33cu.write_database()
+
+    print("Created project: {}".format(project_name))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This code makes calculations faster by:
- Copying base projects instead of importing ecoinvent each time
- Not writing the tree databases to SQLite, only creating processed arrays (`backend.py`)

It also improves the workflow.

To use the PR, first create base projects with ecoinvent 2.2 and ecoinvent 3.3, using the `setup_projects.py` script, e.g.

    python setup_projects.py --version=2 --path="some path to 2.2"
    python setup_projects.py --version=3 --path="some path to 3.3"
 
Then, run the `comparison_cli.py` script, e.g.

    python comparison_cli.py --version=2 --cutoff=0.1 --output="some directory" --iterations=100 --cpus=2

Note that this only allows for one cutoff value.